### PR TITLE
PR for #26 - .NET Standard

### DIFF
--- a/XPlat.Core/Helpers/ParseHelper.cs
+++ b/XPlat.Core/Helpers/ParseHelper.cs
@@ -1,0 +1,259 @@
+﻿namespace XPlat.Helpers
+{
+    using System;
+
+    /// <summary>
+    /// Defines a collection of helper methods for parsing.
+    /// </summary>
+    [Obsolete(
+        "ParseHelper will no longer be maintained as part of the XPlat project. This API may be removed in future XPlat releases.")]
+    public static class ParseHelper
+    {
+        /// <summary>
+        /// Safely parses an object to a boolean.
+        /// </summary>
+        /// <param name="boolean">
+        /// The boolean object.
+        /// </param>
+        /// <returns>
+        /// Returns object parameter as a boolean.
+        /// </returns>
+        public static bool SafeParseBool(object boolean)
+        {
+            bool parsedValue = false;
+            if (boolean != null)
+            {
+                bool.TryParse(boolean.ToString(), out parsedValue);
+            }
+
+            return parsedValue;
+        }
+
+        /// <summary>
+        /// Safely parses an object to an integer.
+        /// </summary>
+        /// <param name="integer">
+        /// The integer object.
+        /// </param>
+        /// <returns>
+        /// Returns object parameter as an integer.
+        /// </returns>
+        public static int SafeParseInt(object integer)
+        {
+            int parsedValue = 0;
+            if (integer != null)
+            {
+                int.TryParse(integer.ToString(), out parsedValue);
+            }
+
+            return parsedValue;
+        }
+
+        /// <summary>
+        /// Safely parses an object to an unsigned integer.
+        /// </summary>
+        /// <param name="integer">
+        /// The unsigned integer object.
+        /// </param>
+        /// <returns>
+        /// Returns object parameter as an unsigned integer.
+        /// </returns>
+        public static uint SafeParseUInt(object integer)
+        {
+            uint result = 0;
+            if (integer != null)
+            {
+                uint.TryParse(integer.ToString(), out result);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Safely parse an object to an Int64 object.
+        /// </summary>
+        /// <param name="integer">
+        /// The integer.
+        /// </param>
+        /// <returns>
+        /// The <see cref="long"/>.
+        /// </returns>
+        public static long SafeParseInt64(object integer)
+        {
+            long parsedValue = 0;
+
+            if (integer != null)
+            {
+                long.TryParse(integer.ToString(), out parsedValue);
+            }
+
+            return parsedValue;
+        }
+
+        /// <summary>
+        /// Safely parse an object to a Guid object.
+        /// </summary>
+        /// <param name="guid">
+        /// The guid.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Guid"/>.
+        /// </returns>
+        public static Guid SafeParseGuid(object guid)
+        {
+            Guid parsedValue = Guid.Empty;
+
+            if (guid != null)
+            {
+                Guid.TryParse(guid.ToString(), out parsedValue);
+            }
+
+            return parsedValue;
+        }
+
+        /// <summary>
+        /// Safely parses an object to a double.
+        /// </summary>
+        /// <param name="dbl">
+        /// The double object.
+        /// </param>
+        /// <returns>
+        /// Returns object parameter as a double.
+        /// </returns>
+        public static double SafeParseDouble(object dbl)
+        {
+            double parsedValue = 0;
+            if (dbl != null)
+            {
+                double.TryParse(dbl.ToString(), out parsedValue);
+            }
+
+            return parsedValue;
+        }
+
+        /// <summary>
+        /// Safely parses an object to a decimal.
+        /// </summary>
+        /// <param name="dcml">
+        /// The decimal object.
+        /// </param>
+        /// <returns>
+        /// Returns object parameter as a decimal.
+        /// </returns>
+        public static decimal SafeParseDecimal(object dcml)
+        {
+            decimal parsedValue = 0;
+            if (dcml != null)
+            {
+                decimal.TryParse(dcml.ToString(), out parsedValue);
+            }
+
+            return parsedValue;
+        }
+
+        /// <summary>
+        /// Safely parses an object to a string.
+        /// </summary>
+        /// <param name="str">
+        /// The string object.
+        /// </param>
+        /// <returns>
+        /// Returns object parameter as a string.
+        /// </returns>
+        public static string SafeParseString(object str)
+        {
+            string parsedValue = string.Empty;
+            if (str != null)
+            {
+                parsedValue = str.ToString();
+            }
+
+            return parsedValue;
+        }
+
+        /// <summary>
+        /// Safely parses an object to a float.
+        /// </summary>
+        /// <param name="flt">
+        /// The float object.
+        /// </param>
+        /// <returns>
+        /// The <see cref="float"/>.
+        /// </returns>
+        public static float SafeParseFloat(object flt)
+        {
+            float parsedValue = 0;
+
+            if (flt != null)
+            {
+                float.TryParse(flt.ToString(), out parsedValue);
+            }
+
+            return parsedValue;
+        }
+
+        /// <summary>
+        /// Safely parses an object to an enum value.
+        /// </summary>
+        /// <param name="enumValue">
+        /// The enum object.
+        /// </param>
+        /// <typeparam name="TEnum">
+        /// The type of Enum.
+        /// </typeparam>
+        /// <returns>
+        /// Returns object parameter as an enum value.
+        /// </returns>
+        public static TEnum SafeParseEnum<TEnum>(object enumValue)
+            where TEnum : struct
+        {
+            TEnum parsedValue = default(TEnum);
+            if (enumValue != null)
+            {
+                Enum.TryParse(enumValue.ToString(), out parsedValue);
+            }
+
+            return parsedValue;
+        }
+
+        /// <summary>
+        /// Safely parses an object to a <see cref="DateTime"/> value.
+        /// </summary>
+        /// <param name="dateTime">
+        /// The date time object.
+        /// </param>
+        /// <returns>
+        /// Returns object parameter as a DateTime.
+        /// </returns>
+        public static DateTime SafeParseDateTime(object dateTime)
+        {
+            DateTime parsedValue = DateTime.MinValue;
+            if (dateTime != null)
+            {
+                DateTime.TryParse(dateTime.ToString(), out parsedValue);
+            }
+
+            return parsedValue;
+        }
+
+        /// <summary>
+        /// Safely parses an object to a <see cref="DateTimeOffset"/> value.
+        /// </summary>
+        /// <param name="dateTimeOffset">
+        /// The date time offset object.
+        /// </param>
+        /// <returns>
+        /// Returns object parameter as a DateTimeOffset.
+        /// </returns>
+        public static DateTimeOffset SafeParseDateTimeOffset(object dateTimeOffset)
+        {
+            DateTimeOffset parsedValue = DateTimeOffset.MinValue;
+            if (dateTimeOffset != null)
+            {
+                DateTimeOffset.TryParse(dateTimeOffset.ToString(), out parsedValue);
+            }
+
+            return parsedValue;
+        }
+    }
+}

--- a/XPlat.Devices.Display/DisplayRequest.Android.cs
+++ b/XPlat.Devices.Display/DisplayRequest.Android.cs
@@ -1,5 +1,5 @@
 ﻿#if __ANDROID__
-namespace XPlat.Devices.Display
+namespace XPlat.Device.Display
 {
     using System;
     using Android.Views;

--- a/XPlat.Devices.Display/DisplayRequest.Windows.cs
+++ b/XPlat.Devices.Display/DisplayRequest.Windows.cs
@@ -1,5 +1,5 @@
 ﻿#if WINDOWS_UWP
-namespace XPlat.Devices.Display
+namespace XPlat.Device.Display
 {
     /// <summary>Represents a display request.</summary>
     public class DisplayRequest : IDisplayRequest

--- a/XPlat.Devices.Display/DisplayRequest.iOS.cs
+++ b/XPlat.Devices.Display/DisplayRequest.iOS.cs
@@ -1,5 +1,5 @@
 ﻿#if __IOS__
-namespace XPlat.Devices.Display
+namespace XPlat.Device.Display
 {
     using UIKit;
 

--- a/XPlat.Devices.Display/IDisplayRequest.cs
+++ b/XPlat.Devices.Display/IDisplayRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Display
+﻿namespace XPlat.Device.Display
 {
     /// <summary>Represents a display request.</summary>
     public interface IDisplayRequest

--- a/XPlat.Devices.Display/XPlat.Device.Display.csproj
+++ b/XPlat.Devices.Display/XPlat.Device.Display.csproj
@@ -7,21 +7,21 @@
     <Version>1.0.0.0</Version>
     <Authors>James Croft</Authors>
     <Company>James Croft</Company>
-    <Product>XPlat - Windows.System.Power APIs</Product>
-    <Description>Brings the functionality of the Windows.System.Power APIs cross-platform with support for Windows, Android and iOS.</Description>
+    <Product>XPlat - Windows.System.Display APIs</Product>
+    <Description>Brings the functionality of the Windows.System.Display APIs cross-platform with support for Windows, Android and iOS.</Description>
     <Copyright>Copyright (C) James Croft. All rights reserved.</Copyright>
     <PackageLicenseUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs</PackageProjectUrl>
     <PackageIconUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs/blob/develop/Assets/ProjectIcon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Xamarin UWP iOS Android Toolkit API Extensions Components Power PowerManager</PackageTags>
+    <PackageTags>Xamarin UWP iOS Android Toolkit API Extensions Components Display DisplayRequest</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <PackageId>XPlat.Devices.Power</PackageId>
+    <PackageId>XPlat.Device.Display</PackageId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.4\XPlat.Devices.Power.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\netstandard1.4\XPlat.Device.Display.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XPlat.Devices.Geolocation/BasicGeoposition.cs
+++ b/XPlat.Devices.Geolocation/BasicGeoposition.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     /// <summary>The basic information to describe a geographic position.</summary>
     public struct BasicGeoposition

--- a/XPlat.Devices.Geolocation/Extensions/GeolocationAccessStatusExtensions.cs
+++ b/XPlat.Devices.Geolocation/Extensions/GeolocationAccessStatusExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation.Extensions
+﻿namespace XPlat.Device.Geolocation.Extensions
 {
     using System;
 

--- a/XPlat.Devices.Geolocation/Extensions/PositionStatusExtensions.cs
+++ b/XPlat.Devices.Geolocation/Extensions/PositionStatusExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation.Extensions
+﻿namespace XPlat.Device.Geolocation.Extensions
 {
     using System;
 

--- a/XPlat.Devices.Geolocation/Geocoordinate.cs
+++ b/XPlat.Devices.Geolocation/Geocoordinate.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     using System;
 

--- a/XPlat.Devices.Geolocation/GeolocationAccessStatus.cs
+++ b/XPlat.Devices.Geolocation/GeolocationAccessStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     /// <summary>Indicates if your app has permission to access location data.</summary>
     public enum GeolocationAccessStatus

--- a/XPlat.Devices.Geolocation/Geolocator.Android.cs
+++ b/XPlat.Devices.Geolocation/Geolocator.Android.cs
@@ -1,5 +1,5 @@
 ﻿#if __ANDROID__
-namespace XPlat.Devices.Geolocation
+namespace XPlat.Device.Geolocation
 {
     using System;
     using System.Linq;

--- a/XPlat.Devices.Geolocation/Geolocator.Windows.cs
+++ b/XPlat.Devices.Geolocation/Geolocator.Windows.cs
@@ -1,10 +1,10 @@
 ﻿#if WINDOWS_UWP
-namespace XPlat.Devices.Geolocation
+namespace XPlat.Device.Geolocation
 {
     using System;
     using System.Threading.Tasks;
     using Windows.Foundation;
-    using XPlat.Devices.Geolocation.Extensions;
+    using XPlat.Device.Geolocation.Extensions;
     using XPlat.Threading.Tasks;
 
     public class Geolocator : IGeolocator

--- a/XPlat.Devices.Geolocation/Geolocator.iOS.cs
+++ b/XPlat.Devices.Geolocation/Geolocator.iOS.cs
@@ -1,5 +1,5 @@
 ﻿#if __IOS__
-namespace XPlat.Devices.Geolocation
+namespace XPlat.Device.Geolocation
 {
     using System;
     using System.Threading.Tasks;

--- a/XPlat.Devices.Geolocation/GeolocatorException.cs
+++ b/XPlat.Devices.Geolocation/GeolocatorException.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     using System;
 

--- a/XPlat.Devices.Geolocation/GeolocatorLocationListener.Android.cs
+++ b/XPlat.Devices.Geolocation/GeolocatorLocationListener.Android.cs
@@ -1,5 +1,5 @@
 ﻿#if __ANDROID__
-namespace XPlat.Devices.Geolocation
+namespace XPlat.Device.Geolocation
 {
     using System;
     using System.Collections.Generic;

--- a/XPlat.Devices.Geolocation/Geopoint.cs
+++ b/XPlat.Devices.Geolocation/Geopoint.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     /// <summary>Describes a geographic point.</summary>
     public class Geopoint : IGeopoint

--- a/XPlat.Devices.Geolocation/Geoposition.cs
+++ b/XPlat.Devices.Geolocation/Geoposition.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     /// <summary>Represents a location that may contain latitude and longitude data.</summary>
     public class Geoposition : IGeoposition

--- a/XPlat.Devices.Geolocation/IGeocoordinate.cs
+++ b/XPlat.Devices.Geolocation/IGeocoordinate.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     using System;
 

--- a/XPlat.Devices.Geolocation/IGeolocator.cs
+++ b/XPlat.Devices.Geolocation/IGeolocator.cs
@@ -2,7 +2,7 @@
 // Copyright (c) James Croft. All rights reserved.
 // </copyright>
 
-namespace XPlat.Devices.Geolocation
+namespace XPlat.Device.Geolocation
 {
     using System;
     using System.Threading.Tasks;

--- a/XPlat.Devices.Geolocation/IGeopoint.cs
+++ b/XPlat.Devices.Geolocation/IGeopoint.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     /// <summary>Describes a geographic point.</summary>
     public interface IGeopoint

--- a/XPlat.Devices.Geolocation/IGeoposition.cs
+++ b/XPlat.Devices.Geolocation/IGeoposition.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     /// <summary>Represents a location that may contain latitude and longitude data.</summary>
     public interface IGeoposition

--- a/XPlat.Devices.Geolocation/IStatusChangedEventArgs.cs
+++ b/XPlat.Devices.Geolocation/IStatusChangedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     /// <summary>Provides information for the StatusChanged event.</summary>
     public interface IStatusChangedEventArgs

--- a/XPlat.Devices.Geolocation/LocationRetriever.Android.cs
+++ b/XPlat.Devices.Geolocation/LocationRetriever.Android.cs
@@ -1,5 +1,5 @@
 ﻿#if __ANDROID__
-namespace XPlat.Devices.Geolocation
+namespace XPlat.Device.Geolocation
 {
     using System;
     using System.Collections.Generic;

--- a/XPlat.Devices.Geolocation/PositionAccuracy.cs
+++ b/XPlat.Devices.Geolocation/PositionAccuracy.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     /// <summary>Indicates the requested accuracy level for the location data that the application uses.</summary>
     public enum PositionAccuracy

--- a/XPlat.Devices.Geolocation/PositionChangedEventArgs.cs
+++ b/XPlat.Devices.Geolocation/PositionChangedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     /// <summary>Provides data for the PositionChanged event.</summary>
     public class PositionChangedEventArgs

--- a/XPlat.Devices.Geolocation/PositionStatus.cs
+++ b/XPlat.Devices.Geolocation/PositionStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     /// <summary>Indicates the ability of the Geolocator object to provide location data.</summary>
     public enum PositionStatus

--- a/XPlat.Devices.Geolocation/StatusChangedEventArgs.cs
+++ b/XPlat.Devices.Geolocation/StatusChangedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Geolocation
+﻿namespace XPlat.Device.Geolocation
 {
     /// <summary>Provides information for the StatusChanged event.</summary>
     public class StatusChangedEventArgs : IStatusChangedEventArgs
@@ -12,13 +12,13 @@
         public StatusChangedEventArgs(Windows.Devices.Geolocation.PositionStatus status)
         {
             this.Status =
-                XPlat.Devices.Geolocation.Extensions.PositionStatusExtensions.ToInternalPositionStatus(status);
+                XPlat.Device.Geolocation.Extensions.PositionStatusExtensions.ToInternalPositionStatus(status);
         }
 
         public StatusChangedEventArgs(Windows.Devices.Geolocation.StatusChangedEventArgs eventArgs)
         {
             this.Status =
-                XPlat.Devices.Geolocation.Extensions.PositionStatusExtensions
+                XPlat.Device.Geolocation.Extensions.PositionStatusExtensions
                     .ToInternalPositionStatus(eventArgs.Status);
         }
 #endif

--- a/XPlat.Devices.Geolocation/XPlat.Device.Geolocation.csproj
+++ b/XPlat.Devices.Geolocation/XPlat.Device.Geolocation.csproj
@@ -7,21 +7,21 @@
     <Version>1.0.0.0</Version>
     <Authors>James Croft</Authors>
     <Company>James Croft</Company>
-    <Product>XPlat - Windows.System.Display APIs</Product>
-    <Description>Brings the functionality of the Windows.System.Display APIs cross-platform with support for Windows, Android and iOS.</Description>
+    <Product>XPlat - Windows.Devices.Geolocation APIs</Product>
+    <Description>Brings the functionality of the Windows.Devices.Geolocation APIs cross-platform with support for Windows, Android and iOS.</Description>
     <Copyright>Copyright (C) James Croft. All rights reserved.</Copyright>
     <PackageLicenseUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs</PackageProjectUrl>
     <PackageIconUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs/blob/develop/Assets/ProjectIcon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Xamarin UWP iOS Android Toolkit API Extensions Components Display DisplayRequest</PackageTags>
+    <PackageTags>Xamarin UWP iOS Android Toolkit API Extensions Components Geolocation Geolocator</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <PackageId>XPlat.Devices.Display</PackageId>
+    <PackageId>XPlat.Device.Geolocation</PackageId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.4\XPlat.Devices.Display.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\netstandard1.4\XPlat.Device.Geolocation.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,12 +38,18 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">
     <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'xamarin.ios10' ">
+    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\XPlat.Foundation\XPlat.Foundation.csproj" />
+  </ItemGroup>
+
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
+
 
 </Project>

--- a/XPlat.Devices.Launcher/Extensions/LaunchQuerySupportStatusExtensions.cs
+++ b/XPlat.Devices.Launcher/Extensions/LaunchQuerySupportStatusExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Extensions
+﻿namespace XPlat.Device.Extensions
 {
     using System;
 

--- a/XPlat.Devices.Launcher/ILauncher.cs
+++ b/XPlat.Devices.Launcher/ILauncher.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices
+﻿namespace XPlat.Device
 {
     using System;
     using System.Threading.Tasks;

--- a/XPlat.Devices.Launcher/LaunchQuerySupportStatus.cs
+++ b/XPlat.Devices.Launcher/LaunchQuerySupportStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices
+﻿namespace XPlat.Device
 {
     /// <summary>Specifies whether an app is available that supports activation.</summary>
     public enum LaunchQuerySupportStatus

--- a/XPlat.Devices.Launcher/Launcher.Android.cs
+++ b/XPlat.Devices.Launcher/Launcher.Android.cs
@@ -1,5 +1,5 @@
 ﻿#if __ANDROID__
-namespace XPlat.Devices
+namespace XPlat.Device
 {
     using System;
     using System.Threading.Tasks;

--- a/XPlat.Devices.Launcher/Launcher.Windows.cs
+++ b/XPlat.Devices.Launcher/Launcher.Windows.cs
@@ -1,10 +1,10 @@
 ﻿#if WINDOWS_UWP
-namespace XPlat.Devices
+namespace XPlat.Device
 {
     using System;
     using System.Threading.Tasks;
     using Windows.System;
-    using XPlat.Devices.Extensions;
+    using XPlat.Device.Extensions;
     using XPlat.Storage;
 
     /// <summary>Starts the default app associated with the specified file or URI.</summary>

--- a/XPlat.Devices.Launcher/XPlat.Device.Launcher.csproj
+++ b/XPlat.Devices.Launcher/XPlat.Device.Launcher.csproj
@@ -7,21 +7,22 @@
     <Version>1.0.0.0</Version>
     <Authors>James Croft</Authors>
     <Company>James Croft</Company>
-    <Product>XPlat - Windows.Devices.Geolocation APIs</Product>
-    <Description>Brings the functionality of the Windows.Devices.Geolocation APIs cross-platform with support for Windows, Android and iOS.</Description>
+    <Product>XPlat - Windows.System.Launcher APIs</Product>
+    <Description>Brings the functionality of the Windows.System.Launcher APIs cross-platform with support for Windows, Android and iOS.</Description>
     <Copyright>Copyright (C) James Croft. All rights reserved.</Copyright>
     <PackageLicenseUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs</PackageProjectUrl>
     <PackageIconUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs/blob/develop/Assets/ProjectIcon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Xamarin UWP iOS Android Toolkit API Extensions Components Geolocation Geolocator</PackageTags>
+    <PackageTags>Xamarin UWP iOS Android Toolkit API Extensions Components Launcher File URI</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <PackageId>XPlat.Devices.Geolocation</PackageId>
+    <PackageId>XPlat.Device.Launcher</PackageId>
+    <RootNamespace>XPlat.Device</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.4\XPlat.Devices.Geolocation.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\netstandard1.4\XPlat.Device.Launcher.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,18 +39,12 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
-    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'xamarin.ios10' ">
-    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\XPlat.Foundation\XPlat.Foundation.csproj" />
+    <ProjectReference Include="..\XPlat.Storage\XPlat.Storage.csproj" />
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
-
 
 </Project>

--- a/XPlat.Devices.Power/BatteryStatus.cs
+++ b/XPlat.Devices.Power/BatteryStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Power
+﻿namespace XPlat.Device.Power
 {
     /// <summary>Indicates the status of the battery.</summary>
     public enum BatteryStatus

--- a/XPlat.Devices.Power/BatteryStatusChangedEventArgs.cs
+++ b/XPlat.Devices.Power/BatteryStatusChangedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Power
+﻿namespace XPlat.Device.Power
 {
     using System;
 

--- a/XPlat.Devices.Power/BatteryStatusChangedEventHandler.cs
+++ b/XPlat.Devices.Power/BatteryStatusChangedEventHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Power
+﻿namespace XPlat.Device.Power
 {
     public delegate void BatteryStatusChangedEventHandler(object sender, BatteryStatusChangedEventArgs args);
 }

--- a/XPlat.Devices.Power/Extensions/BatteryStatusExtensions.cs
+++ b/XPlat.Devices.Power/Extensions/BatteryStatusExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Power.Extensions
+﻿namespace XPlat.Device.Power.Extensions
 {
     using System;
 

--- a/XPlat.Devices.Power/IPowerManager.cs
+++ b/XPlat.Devices.Power/IPowerManager.cs
@@ -1,4 +1,4 @@
-﻿namespace XPlat.Devices.Power
+﻿namespace XPlat.Device.Power
 {
     using System;
 

--- a/XPlat.Devices.Power/PowerManager.Android.cs
+++ b/XPlat.Devices.Power/PowerManager.Android.cs
@@ -1,5 +1,5 @@
 ﻿#if __ANDROID__
-namespace XPlat.Devices.Power
+namespace XPlat.Device.Power
 {
     using System;
     using System.Threading;

--- a/XPlat.Devices.Power/PowerManager.Windows.cs
+++ b/XPlat.Devices.Power/PowerManager.Windows.cs
@@ -1,9 +1,9 @@
 ﻿#if WINDOWS_UWP
-namespace XPlat.Devices.Power
+namespace XPlat.Device.Power
 {
     using System;
     using System.Threading;
-    using XPlat.Devices.Power.Extensions;
+    using XPlat.Device.Power.Extensions;
 
     /// <summary>Provides access to information about a device's battery and power supply status.</summary>
     public sealed class PowerManager : IPowerManager, IDisposable

--- a/XPlat.Devices.Power/PowerManager.iOS.cs
+++ b/XPlat.Devices.Power/PowerManager.iOS.cs
@@ -1,5 +1,5 @@
 ﻿#if __IOS__
-namespace XPlat.Devices.Power
+namespace XPlat.Device.Power
 {
     using System;
     using System.Threading;

--- a/XPlat.Devices.Power/PowerReceiver.Android.cs
+++ b/XPlat.Devices.Power/PowerReceiver.Android.cs
@@ -1,5 +1,5 @@
 ﻿#if __ANDROID__
-namespace XPlat.Devices.Power
+namespace XPlat.Device.Power
 {
     using System;
 

--- a/XPlat.Devices.Power/XPlat.Device.Power.csproj
+++ b/XPlat.Devices.Power/XPlat.Device.Power.csproj
@@ -7,22 +7,21 @@
     <Version>1.0.0.0</Version>
     <Authors>James Croft</Authors>
     <Company>James Croft</Company>
-    <Product>XPlat - Windows.System.Launcher APIs</Product>
-    <Description>Brings the functionality of the Windows.System.Launcher APIs cross-platform with support for Windows, Android and iOS.</Description>
+    <Product>XPlat - Windows.System.Power APIs</Product>
+    <Description>Brings the functionality of the Windows.System.Power APIs cross-platform with support for Windows, Android and iOS.</Description>
     <Copyright>Copyright (C) James Croft. All rights reserved.</Copyright>
     <PackageLicenseUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs</PackageProjectUrl>
     <PackageIconUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs/blob/develop/Assets/ProjectIcon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/jamesmcroft/XPlat-Windows-APIs</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Xamarin UWP iOS Android Toolkit API Extensions Components Launcher File URI</PackageTags>
+    <PackageTags>Xamarin UWP iOS Android Toolkit API Extensions Components Power PowerManager</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-    <PackageId>XPlat.Devices.Launcher</PackageId>
-    <RootNamespace>XPlat.Devices</RootNamespace>
+    <PackageId>XPlat.Device.Power</PackageId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.4\XPlat.Devices.Launcher.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\netstandard1.4\XPlat.Device.Power.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -41,8 +40,8 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\XPlat.Storage\XPlat.Storage.csproj" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">
+    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/XPlat.Samples.Android/XPlat.Samples.Android.csproj
+++ b/XPlat.Samples.Android/XPlat.Samples.Android.csproj
@@ -157,21 +157,21 @@
       <Project>{77a76f2f-5226-4454-b030-d4dfdec6573b}</Project>
       <Name>XPlat.Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Display\XPlat.Devices.Display.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Display\XPlat.Device.Display.csproj">
       <Project>{ca8bd9a9-288f-4af7-8cfc-3b65d2776b0c}</Project>
-      <Name>XPlat.Devices.Display</Name>
+      <Name>XPlat.Device.Display</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Geolocation\XPlat.Devices.Geolocation.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Geolocation\XPlat.Device.Geolocation.csproj">
       <Project>{43d61348-7b9c-4e96-b4e6-9ab34537ef3c}</Project>
-      <Name>XPlat.Devices.Geolocation</Name>
+      <Name>XPlat.Device.Geolocation</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Launcher\XPlat.Devices.Launcher.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Launcher\XPlat.Device.Launcher.csproj">
       <Project>{75fbcf99-a80e-4a3e-9bd2-94faf0fc9022}</Project>
-      <Name>XPlat.Devices.Launcher</Name>
+      <Name>XPlat.Device.Launcher</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Power\XPlat.Devices.Power.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Power\XPlat.Device.Power.csproj">
       <Project>{b094382d-916b-49bc-93f5-3e06e464a008}</Project>
-      <Name>XPlat.Devices.Power</Name>
+      <Name>XPlat.Device.Power</Name>
     </ProjectReference>
     <ProjectReference Include="..\XPlat.Foundation\XPlat.Foundation.csproj">
       <Project>{32e91160-ad0a-4ae1-944b-0f39305bc65c}</Project>

--- a/XPlat.UnitTests.Android/XPlat.UnitTests.Android.csproj
+++ b/XPlat.UnitTests.Android/XPlat.UnitTests.Android.csproj
@@ -121,21 +121,21 @@
       <Project>{77a76f2f-5226-4454-b030-d4dfdec6573b}</Project>
       <Name>XPlat.Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Display\XPlat.Devices.Display.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Display\XPlat.Device.Display.csproj">
       <Project>{ca8bd9a9-288f-4af7-8cfc-3b65d2776b0c}</Project>
-      <Name>XPlat.Devices.Display</Name>
+      <Name>XPlat.Device.Display</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Geolocation\XPlat.Devices.Geolocation.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Geolocation\XPlat.Device.Geolocation.csproj">
       <Project>{43d61348-7b9c-4e96-b4e6-9ab34537ef3c}</Project>
-      <Name>XPlat.Devices.Geolocation</Name>
+      <Name>XPlat.Device.Geolocation</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Launcher\XPlat.Devices.Launcher.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Launcher\XPlat.Device.Launcher.csproj">
       <Project>{75fbcf99-a80e-4a3e-9bd2-94faf0fc9022}</Project>
-      <Name>XPlat.Devices.Launcher</Name>
+      <Name>XPlat.Device.Launcher</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Power\XPlat.Devices.Power.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Power\XPlat.Device.Power.csproj">
       <Project>{b094382d-916b-49bc-93f5-3e06e464a008}</Project>
-      <Name>XPlat.Devices.Power</Name>
+      <Name>XPlat.Device.Power</Name>
     </ProjectReference>
     <ProjectReference Include="..\XPlat.Foundation\XPlat.Foundation.csproj">
       <Project>{32e91160-ad0a-4ae1-944b-0f39305bc65c}</Project>

--- a/XPlat.UnitTests.Windows/XPlat.UnitTests.Windows.csproj
+++ b/XPlat.UnitTests.Windows/XPlat.UnitTests.Windows.csproj
@@ -145,21 +145,21 @@
       <Project>{77a76f2f-5226-4454-b030-d4dfdec6573b}</Project>
       <Name>XPlat.Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Display\XPlat.Devices.Display.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Display\XPlat.Device.Display.csproj">
       <Project>{ca8bd9a9-288f-4af7-8cfc-3b65d2776b0c}</Project>
-      <Name>XPlat.Devices.Display</Name>
+      <Name>XPlat.Device.Display</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Geolocation\XPlat.Devices.Geolocation.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Geolocation\XPlat.Device.Geolocation.csproj">
       <Project>{43d61348-7b9c-4e96-b4e6-9ab34537ef3c}</Project>
-      <Name>XPlat.Devices.Geolocation</Name>
+      <Name>XPlat.Device.Geolocation</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Launcher\XPlat.Devices.Launcher.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Launcher\XPlat.Device.Launcher.csproj">
       <Project>{75fbcf99-a80e-4a3e-9bd2-94faf0fc9022}</Project>
-      <Name>XPlat.Devices.Launcher</Name>
+      <Name>XPlat.Device.Launcher</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Power\XPlat.Devices.Power.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Power\XPlat.Device.Power.csproj">
       <Project>{b094382d-916b-49bc-93f5-3e06e464a008}</Project>
-      <Name>XPlat.Devices.Power</Name>
+      <Name>XPlat.Device.Power</Name>
     </ProjectReference>
     <ProjectReference Include="..\XPlat.Foundation\XPlat.Foundation.csproj">
       <Project>{32e91160-ad0a-4ae1-944b-0f39305bc65c}</Project>

--- a/XPlat.UnitTests.iOS/XPlat.UnitTests.iOS.csproj
+++ b/XPlat.UnitTests.iOS/XPlat.UnitTests.iOS.csproj
@@ -156,21 +156,21 @@
       <Project>{77a76f2f-5226-4454-b030-d4dfdec6573b}</Project>
       <Name>XPlat.Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Display\XPlat.Devices.Display.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Display\XPlat.Device.Display.csproj">
       <Project>{ca8bd9a9-288f-4af7-8cfc-3b65d2776b0c}</Project>
-      <Name>XPlat.Devices.Display</Name>
+      <Name>XPlat.Device.Display</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Geolocation\XPlat.Devices.Geolocation.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Geolocation\XPlat.Device.Geolocation.csproj">
       <Project>{43d61348-7b9c-4e96-b4e6-9ab34537ef3c}</Project>
-      <Name>XPlat.Devices.Geolocation</Name>
+      <Name>XPlat.Device.Geolocation</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Launcher\XPlat.Devices.Launcher.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Launcher\XPlat.Device.Launcher.csproj">
       <Project>{75fbcf99-a80e-4a3e-9bd2-94faf0fc9022}</Project>
-      <Name>XPlat.Devices.Launcher</Name>
+      <Name>XPlat.Device.Launcher</Name>
     </ProjectReference>
-    <ProjectReference Include="..\XPlat.Devices.Power\XPlat.Devices.Power.csproj">
+    <ProjectReference Include="..\XPlat.Devices.Power\XPlat.Device.Power.csproj">
       <Project>{b094382d-916b-49bc-93f5-3e06e464a008}</Project>
-      <Name>XPlat.Devices.Power</Name>
+      <Name>XPlat.Device.Power</Name>
     </ProjectReference>
     <ProjectReference Include="..\XPlat.Foundation\XPlat.Foundation.csproj">
       <Project>{32e91160-ad0a-4ae1-944b-0f39305bc65c}</Project>

--- a/XPlat.UnitTests/XPlat.UnitTests.csproj
+++ b/XPlat.UnitTests/XPlat.UnitTests.csproj
@@ -14,10 +14,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
-    <ProjectReference Include="..\XPlat.Devices.Display\XPlat.Devices.Display.csproj" />
-    <ProjectReference Include="..\XPlat.Devices.Geolocation\XPlat.Devices.Geolocation.csproj" />
-    <ProjectReference Include="..\XPlat.Devices.Launcher\XPlat.Devices.Launcher.csproj" />
-    <ProjectReference Include="..\XPlat.Devices.Power\XPlat.Devices.Power.csproj" />
+    <ProjectReference Include="..\XPlat.Devices.Display\XPlat.Device.Display.csproj" />
+    <ProjectReference Include="..\XPlat.Devices.Geolocation\XPlat.Device.Geolocation.csproj" />
+    <ProjectReference Include="..\XPlat.Devices.Launcher\XPlat.Device.Launcher.csproj" />
+    <ProjectReference Include="..\XPlat.Devices.Power\XPlat.Device.Power.csproj" />
     <ProjectReference Include="..\XPlat.Foundation\XPlat.Foundation.csproj" />
     <ProjectReference Include="..\XPlat.Media.Capture\XPlat.Media.Capture.csproj" />
     <ProjectReference Include="..\XPlat.Storage.Pickers\XPlat.Storage.Pickers.csproj" />

--- a/XPlat.sln
+++ b/XPlat.sln
@@ -7,21 +7,21 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "API", "API", "{D1AEF003-632
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{D999DCBF-510C-47AC-8B80-3995DDEB9855}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Devices.Geolocation", "XPlat.Devices.Geolocation\XPlat.Devices.Geolocation.csproj", "{43D61348-7B9C-4E96-B4E6-9AB34537EF3C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Device.Geolocation", "XPlat.Devices.Geolocation\XPlat.Device.Geolocation.csproj", "{43D61348-7B9C-4E96-B4E6-9AB34537EF3C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Devices.Display", "XPlat.Devices.Display\XPlat.Devices.Display.csproj", "{CA8BD9A9-288F-4AF7-8CFC-3B65D2776B0C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Device.Display", "XPlat.Devices.Display\XPlat.Device.Display.csproj", "{CA8BD9A9-288F-4AF7-8CFC-3B65D2776B0C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Foundation", "XPlat.Foundation\XPlat.Foundation.csproj", "{32E91160-AD0A-4AE1-944B-0F39305BC65C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Core", "XPlat.Core\XPlat.Core.csproj", "{77A76F2F-5226-4454-B030-D4DFDEC6573B}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Devices.Launcher", "XPlat.Devices.Launcher\XPlat.Devices.Launcher.csproj", "{75FBCF99-A80E-4A3E-9BD2-94FAF0FC9022}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Device.Launcher", "XPlat.Devices.Launcher\XPlat.Device.Launcher.csproj", "{75FBCF99-A80E-4A3E-9BD2-94FAF0FC9022}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Storage", "XPlat.Storage\XPlat.Storage.csproj", "{212B0428-3E12-4490-A3CA-7609D26FED19}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.UnitTests", "XPlat.UnitTests\XPlat.UnitTests.csproj", "{873A2FF4-B5EB-49BB-AA06-557E0E2BDBD0}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Devices.Power", "XPlat.Devices.Power\XPlat.Devices.Power.csproj", "{B094382D-916B-49BC-93F5-3E06E464A008}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Device.Power", "XPlat.Devices.Power\XPlat.Device.Power.csproj", "{B094382D-916B-49BC-93F5-3E06E464A008}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.Media.Capture", "XPlat.Media.Capture\XPlat.Media.Capture.csproj", "{C4504BBD-E3D3-4D2E-BE83-865EAF558AA9}"
 EndProject


### PR DESCRIPTION
This PR includes the re-addition of the ParseHelper which is now marked as Obsolete.

Also renamed the projects and namespaces for the XPlat.Devices projects back to XPlat.Device to prevent confusion of update.